### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,7 +1,7 @@
-AM2320  KEYWORD1
-begin   KEYWORD2
-measure KEYWORD2
-measureTemperature  KEYWORD2
-measureHumidity KEYWORD2
-getTemperature  KEYWORD2
-getHumidity KEYWORD2
+AM2320	KEYWORD1
+begin	KEYWORD2
+measure	KEYWORD2
+measureTemperature	KEYWORD2
+measureHumidity	KEYWORD2
+getTemperature	KEYWORD2
+getHumidity	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords